### PR TITLE
Chore/Add PHP 8.5 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ["8.2", "8.3", "8.4"]
+        php-version: ["8.2", "8.3", "8.4", "8.5"]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
PHP 8.5 has been in active support since November 2025 and is accepted by every Laravel version this package targets, but it was missing from the matrix.

CI only — no constraint change, so no release needed.